### PR TITLE
Try to fix the support form's lack of the CSRF token

### DIFF
--- a/portal/templates/support_email_form.html
+++ b/portal/templates/support_email_form.html
@@ -13,6 +13,9 @@
         <h2>Need Support?</h2>
         <hr/>
         <form role="form" action="{{url_for('support')}}" method="POST">
+          <div class="form-group">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          </div>
 
           <div class="form-group">
             <label for="description">Questions/Comments <span id="asterik">*</span></label>


### PR DESCRIPTION
This will hopefully fix the problem recently reported in OSG Slack:

> Hi all, I'm not sure if this is a known problem, the Contact Us form at https://osgconnect.net/support is broken. When I try submitting a request it tells me "400 Bad Request: The CSRF token is missing"